### PR TITLE
Allow configuring `compile_args!` capacity

### DIFF
--- a/src/argument.rs
+++ b/src/argument.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 use crate::{
-    format::{Fmt, FormatArgument, StrLength, Pad, StrFormat},
+    format::{Fmt, FormatArgument, Pad, StrFormat, StrLength},
     utils::{assert_is_ascii, count_chars, ClippedStr},
     CompileArgs,
 };

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 use crate::{
-    format::{Fmt, FormatArgument, FormattedLen, Pad, StrFormat},
+    format::{Fmt, FormatArgument, StrLength, Pad, StrFormat},
     utils::{assert_is_ascii, count_chars, ClippedStr},
     CompileArgs,
 };
@@ -17,22 +17,22 @@ enum ArgumentInner<'a> {
 }
 
 impl ArgumentInner<'_> {
-    const fn formatted_len(&self) -> FormattedLen {
+    const fn formatted_len(&self) -> StrLength {
         match self {
-            Self::Str(s, None) => FormattedLen::for_str(s),
+            Self::Str(s, None) => StrLength::for_str(s),
             Self::Str(s, Some(fmt)) => match ClippedStr::new(s, fmt.clip_at) {
-                ClippedStr::Full(_) => FormattedLen::for_str(s),
-                ClippedStr::Clipped(bytes) => FormattedLen {
+                ClippedStr::Full(_) => StrLength::for_str(s),
+                ClippedStr::Clipped(bytes) => StrLength {
                     bytes: bytes.len() + fmt.using.len(),
                     chars: fmt.clip_at + count_chars(fmt.using),
                 },
             },
-            Self::Char(c) => FormattedLen::for_char(*c),
+            Self::Char(c) => StrLength::for_char(*c),
             Self::Int(value) => {
                 let bytes = (*value < 0) as usize + log_10_ceil(value.unsigned_abs());
-                FormattedLen::ascii(bytes)
+                StrLength::both(bytes)
             }
-            Self::UnsignedInt(value) => FormattedLen::ascii(log_10_ceil(*value)),
+            Self::UnsignedInt(value) => StrLength::both(log_10_ceil(*value)),
         }
     }
 }
@@ -238,6 +238,16 @@ impl<'a> ArgumentWrapper<Ascii<'a>> {
         Argument {
             inner: ArgumentInner::Str(self.value.0, str_fmt),
             pad,
+        }
+    }
+}
+
+impl<'a, const CAP: usize> ArgumentWrapper<&'a CompileArgs<CAP>> {
+    /// Performs the conversion.
+    pub const fn into_argument(self) -> Argument<'a> {
+        Argument {
+            inner: ArgumentInner::Str(self.value.as_str(), None),
+            pad: None,
         }
     }
 }
@@ -455,7 +465,7 @@ mod tests {
                 using: "",
             }),
         );
-        assert_eq!(arg.formatted_len(), FormattedLen::for_str("te"));
+        assert_eq!(arg.formatted_len(), StrLength::for_str("te"));
 
         let arg = ArgumentInner::Str(
             "teßt",
@@ -464,7 +474,7 @@ mod tests {
                 using: "...",
             }),
         );
-        assert_eq!(arg.formatted_len(), FormattedLen::for_str("te..."));
+        assert_eq!(arg.formatted_len(), StrLength::for_str("te..."));
 
         let arg = ArgumentInner::Str(
             "teßt",
@@ -473,7 +483,7 @@ mod tests {
                 using: "…",
             }),
         );
-        assert_eq!(arg.formatted_len(), FormattedLen::for_str("te…"));
+        assert_eq!(arg.formatted_len(), StrLength::for_str("te…"));
 
         let arg = ArgumentInner::Str(
             "teßt",
@@ -482,7 +492,7 @@ mod tests {
                 using: "",
             }),
         );
-        assert_eq!(arg.formatted_len(), FormattedLen::for_str("teß"));
+        assert_eq!(arg.formatted_len(), StrLength::for_str("teß"));
 
         let arg = ArgumentInner::Str(
             "teßt",
@@ -491,7 +501,7 @@ mod tests {
                 using: "…",
             }),
         );
-        assert_eq!(arg.formatted_len(), FormattedLen::for_str("teß…"));
+        assert_eq!(arg.formatted_len(), StrLength::for_str("teß…"));
 
         let arg = ArgumentInner::Str(
             "teßt",
@@ -500,12 +510,12 @@ mod tests {
                 using: "-",
             }),
         );
-        assert_eq!(arg.formatted_len(), FormattedLen::for_str("teß-"));
+        assert_eq!(arg.formatted_len(), StrLength::for_str("teß-"));
 
         for clip_at in [4, 5, 16] {
             for using in ["", "...", "…"] {
                 let arg = ArgumentInner::Str("teßt", Some(StrFormat { clip_at, using }));
-                assert_eq!(arg.formatted_len(), FormattedLen::for_str("teßt"));
+                assert_eq!(arg.formatted_len(), StrLength::for_str("teßt"));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,47 @@
 //! }
 //!```
 //!
+//! ## Printing dynamically-sized messages
+//!
+//! `compile_args!` allows specifying capacity of the produced message. This is particularly useful
+//! when formatting enums (e.g., to compile-format errors):
+//!
+//! ```
+//! # use compile_fmt::{compile_args, fmt, CompileArgs};
+//! #[derive(Debug)]
+//! enum Error {
+//!     Number(u64),
+//!     Tuple(usize, char),
+//! }
+//!
+//! type ErrorArgs = CompileArgs<55>;
+//! // ^ 55 is the exact lower boundary on capacity. It's valid to specify
+//! // a greater value, e.g. 64.
+//!
+//! impl Error {
+//!     const fn fmt(&self) -> ErrorArgs {
+//!         match *self {
+//!             Self::Number(number) => compile_args!(
+//!                 capacity: ErrorArgs::CAPACITY,
+//!                 "don't like number ", number => fmt::<u64>()
+//!             ),
+//!             Self::Tuple(pos, ch) => compile_args!(
+//!                 "don't like char '", ch => fmt::<char>(), "' at position ",
+//!                 pos => fmt::<usize>()
+//!             ),
+//!         }
+//!     }
+//! }
+//!
+//! // `Error::fmt()` can be used as a building block for more complex messages:
+//! let err = Error::Tuple(1_234, '?');
+//! let message = compile_args!("Operation failed: ", &err.fmt() => fmt::<&ErrorArgs>());
+//! assert_eq!(
+//!     message.as_str(),
+//!     "Operation failed: don't like char '?' at position 1234"
+//! );
+//! ```
+//!
 //! See docs for macros and format specifiers for more examples.
 
 #![no_std]
@@ -103,7 +144,7 @@ mod utils;
 pub use crate::argument::{Argument, ArgumentWrapper};
 pub use crate::{
     argument::Ascii,
-    format::{clip, clip_ascii, fmt, Fmt, FormatArgument, StrLength, MaxLength},
+    format::{clip, clip_ascii, fmt, Fmt, FormatArgument, MaxLength, StrLength},
 };
 use crate::{format::StrFormat, utils::ClippedStr};
 
@@ -130,6 +171,19 @@ impl<const CAP: usize> AsRef<str> for CompileArgs<CAP> {
 }
 
 impl<const CAP: usize> CompileArgs<CAP> {
+    /// Capacity of these arguments in bytes.
+    pub const CAPACITY: usize = CAP;
+
+    #[doc(hidden)] // Implementation detail of the `compile_args` macro
+    #[track_caller]
+    pub const fn assert_capacity(required_capacity: usize) {
+        compile_assert!(
+            CAP >= required_capacity,
+            "Insufficient capacity (", CAP => fmt::<usize>(), " bytes) provided \
+             for `compile_args` macro; it requires at least ", required_capacity => fmt::<usize>(), " bytes"
+        );
+    }
+
     const fn new() -> Self {
         Self {
             buffer: [0_u8; CAP],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod utils;
 pub use crate::argument::{Argument, ArgumentWrapper};
 pub use crate::{
     argument::Ascii,
-    format::{clip, clip_ascii, fmt, Fmt, FormatArgument, MaxWidth},
+    format::{clip, clip_ascii, fmt, Fmt, FormatArgument, StrLength, MaxLength},
 };
 use crate::{format::StrFormat, utils::ClippedStr};
 
@@ -228,6 +228,16 @@ impl<const CAP: usize> CompileArgs<CAP> {
             str::from_utf8_unchecked(written_slice)
         }
     }
+}
+
+impl<const CAP: usize> FormatArgument for &CompileArgs<CAP> {
+    type Details = ();
+    const MAX_BYTES_PER_CHAR: usize = 4;
+}
+
+impl<const CAP: usize> MaxLength for &CompileArgs<CAP> {
+    const MAX_LENGTH: StrLength = StrLength::both(CAP);
+    // ^ Here, the byte length is exact and the char length is the pessimistic upper boundary.
 }
 
 #[cfg(doctest)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,6 +12,7 @@
 /// - Strings (`&str`)
 /// - [`Ascii`](crate::Ascii) strings
 /// - Chars (`char`)
+/// - References to [`CompileArgs`](crate::CompileArgs).
 ///
 /// Due to how Rust type inference works, you might need to specify the type suffix for integer
 /// literals (e.g., `42_usize` instead of `42`).
@@ -21,6 +22,12 @@
 /// in a `const fn`.
 ///
 /// The value output by the macro is [`CompileArgs`](crate::CompileArgs).
+///
+/// # Specifying capacity
+///
+/// You can specify capacity of the returned `CompileArgs` by prefacing arguments with `capacity: $cap,`.
+/// Here, `$cap` is a constant expression of type `usize`. The specified capacity must be greater or equal
+/// that the capacity inferred from the arguments; the macro will fail with a compilation error otherwise.
 ///
 /// # See also
 ///
@@ -58,18 +65,40 @@
 /// let args = create_args(100);
 /// assert_eq!(args.to_string(), "2 * x + 3 = 203");
 /// ```
+///
+/// ## Usage with explicit capacity
+///
+/// ```
+/// # use compile_fmt::compile_args;
+/// let args = compile_args!(capacity: 16, "Value: ", 42_i32);
+/// assert_eq!(args.as_str(), "Value: 42");
+/// ```
+///
+/// Insufficient specified capacity will lead to a compilation error:
+///
+/// ```compile_fail
+/// # use compile_fmt::compile_args;
+/// let args = compile_args!(capacity: 4, "Value: ", 42_i32);
+/// ```
+///
+/// The error message will include details about the necessary capacity:
+///
+/// ```text
+/// error[E0080]: evaluation of constant value failed
+///    -->
+///     |
+///     |     let args = compile_args!(capacity: 4, "Value: ", 42_i32);
+///     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/// the evaluated program panicked at 'Insufficient capacity (4 bytes)
+/// provided for `compile_args` macro; it requires at least 9 bytes'
+/// ```
 #[macro_export]
 macro_rules! compile_args {
     (capacity: $cap:expr, $($arg:expr $(=> $fmt:expr)?),+) => {{
         const __CAPACITY: usize = $cap;
         const _: () = {
             let required_capacity = $crate::__compile_args_impl!(@total_capacity $($arg $(=> $fmt)?,)+);
-            let capacity = __CAPACITY;
-            $crate::compile_assert!(
-                capacity >= required_capacity,
-                "Insufficient capacity (", capacity => $crate::fmt::<usize>(), " bytes) provided \
-                 for the macro; it requires at least ", required_capacity => $crate::fmt::<usize>(), " bytes"
-            );
+            $crate::CompileArgs::<__CAPACITY>::assert_capacity(required_capacity);
         };
         $crate::CompileArgs::<__CAPACITY>::format(&[
             $($crate::ArgumentWrapper::new($arg)$(.with_fmt($fmt))?.into_argument(),)+


### PR DESCRIPTION
## What?

Allows configuring `compile_args!` capacity. The capacity is checked against the minimum required capacity in compile time.

## Why?

This is useful for more complex compile-time formatting, e.g. formatting `enum`s.